### PR TITLE
Fix crash on iOS when using advanced payload for alert

### DIFF
--- a/Plugin.AzurePushNotifications/Plugin.AzurePushNotifications.iOS/AzurePushNotificationsImplementation.cs
+++ b/Plugin.AzurePushNotifications/Plugin.AzurePushNotifications.iOS/AzurePushNotificationsImplementation.cs
@@ -84,7 +84,7 @@ namespace Plugin.AzurePushNotifications
                 // so keep that in mind.
                 if(aps.ContainsKey(new NSString("alert")))
                 {
-                    alert = (aps[new NSString("alert")] as NSString).ToString();
+                    alert = (aps[new NSString("alert")] as NSString) ?? "";
                 }
 
                 //If this came from the ReceivedRemoteNotification while the app was running,


### PR DESCRIPTION
Fixes #2 

This fixes an crash on iOS when using advanced payload for alerts;
```json
    "aps": {
        "alert": {
            "title": "Notification Title2",
            "subtitle": "Notification Subtitle",
            "body": "This is the message body of the notification."
        }
    }
```